### PR TITLE
add typescript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "autosuggest-highlight",
   "version": "3.1.1",
   "description": "Utilities for highlighting text in autosuggest and autocomplete components",
+  "types": "types.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/moroshko/autosuggest-highlight.git"

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,29 @@
+declare module "autosuggest-highlight/match" {
+  /**
+   * Calculates the characters to highlight in `text` based on `query`. Optional options can be provided.
+   */
+  export default function match(
+    text: string,
+    query: string,
+    options?: {
+      /** Search inside words (false by default) */
+      insideWords: boolean;
+
+      /** Find all matches of each word in `query` (false by default) */
+      findAllOccurrences: boolean;
+
+      /** Require each word of `query` to be found in `text` or else returns an empty set (false by default) */
+      requireMatchAll: boolean;
+    }
+  ): number[] | number[][];
+}
+
+declare module "autosuggest-highlight/parse" {
+  /**
+   *  Breaks the given `text` to parts based on `matches`.
+   */
+  export default function parse(
+    text: string,
+    matches: number[] | number[][]
+  ): Array<{ text: string; highlight: boolean }>;
+}


### PR DESCRIPTION
Your options-feature is great! We are using your fork for our project. The only downside is that the types at [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/autosuggest-highlight) lags behind your branch. 

We have created updated Typescript-types, so here they are if you want them into your fork.

(Since the DefinitelyTyped types are targeting the original version of this repo, I don't think I should update those).